### PR TITLE
[clang] Remove ClangDataFormat.py from docs

### DIFF
--- a/clang/www/hacking.html
+++ b/clang/www/hacking.html
@@ -89,9 +89,9 @@
       qualifiers, and the <tt>getTypePtr()</tt> method to get the
       wrapped <tt>Type*</tt> which you can then dump.</li>
       <li>For <a href="https://lldb.llvm.org"> <tt>LLDB</tt></a> users there are
-      data formatters for clang data structures in
-      <a href="https://github.com/llvm/llvm-project/blob/main/clang/utils/ClangDataFormat.py">
-      <tt>clang/utils/ClangDataFormat.py</tt></a>.</li>
+      data formatters for LLVM data structures in
+      <a href="https://github.com/llvm/llvm-project/blob/main/llvm/utils/lldbDataFormatters.py">
+      <tt>llvm/utils/lldbDataFormatters.py</tt></a>.</li>
     </ul>
 
   <!--=====================================================================-->


### PR DESCRIPTION
The script was removed in https://github.com/llvm/llvm-project/pull/96385.

Instead, mention the LLVM formatter as it's still very useful for Clang's code.